### PR TITLE
fix: publish built card as release assets so HACS can install (#27)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,8 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   build-and-release:
@@ -33,6 +34,7 @@ jobs:
           mkdir -p release
           cp dist/tracking-number-card.js release/
           cp dist/tracking-number-card.js.map release/
+          gzip -9 -k -c dist/tracking-number-card.js > release/tracking-number-card.js.gz
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 ## Release Process
 
 - Update the version in `package.json` and commit your changes.
-- Create and push a tag matching `v*` (for example, `git tag v4.1.0 && git push origin v4.1.0`).
+- Create and push a version tag, for example `git tag 4.2.2 && git push origin 4.2.2` (a `v`-prefixed tag such as `v4.2.2` also works).
 - The GitHub Actions workflow builds the distribution files and publishes a release with the generated assets.
 
 ## License

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "Tracking Number Card",
     "render_readme": true,
-    "filename": "dist/tracking-number-card.js"
+    "filename": "tracking-number-card.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tracking-number-card",
-  "version": "4.2.0",
+  "version": "4.2.2",
   "description": "A modern Home Assistant card for displaying tracking numbers with clickable links",
   "type": "module",
   "main": "dist/tracking-number-card.js",


### PR DESCRIPTION
## Problem

Installing the card via HACS fails with a **"Configuration Error"** — the `tracking-number-card` custom element never registers (issue #27).

The card code itself is fine. The failure is in **distribution**: HACS installs frontend plugins by downloading the built JS from a GitHub release's **assets**, and **every 4.x release has zero assets**.

### Root cause

- The release workflow (`.github/workflows/release.yaml`) triggers only on tags matching `v*`, but every 4.x release was tagged **without** the `v` prefix (`4.0.0`, `4.1.0`, `4.2.0`). So the workflow **never ran** and no build was ever attached.
  - Confirmed via the GitHub API: `4.2.0`, `4.1.0`, `4.0.0` → 0 assets. The older *working* releases `3.0.3`/`1.3.0` each had 1 asset.
- Secondary: `hacs.json` set `filename` to a path (`dist/tracking-number-card.js`). HACS expects the **basename** and auto-discovers the file in `dist/` or in release assets; the `dist/` prefix can prevent matching.

Net effect: HACS auto-adds a Lovelace resource pointing at a file it never downloaded → module doesn't load → "Configuration Error". This matches the manual workaround in the thread (copy `dist/` files + add the `/hacsfiles/...` resource by hand).

## Changes

- **`release.yaml`** — trigger on both bare-semver and `v`-prefixed version tags so the release runs regardless of prefix; also attach a gzipped `tracking-number-card.js.gz` asset (HA serves the pre-compressed file when present, per the `.gz` note in the issue thread).
- **`hacs.json`** — use the basename `tracking-number-card.js`.
- **`README.md`** — correct the Release Process tag example to match the trigger.
- **`package.json`** — bump to `4.2.2` (`4.2.1` is already a stray tag with no release).

No `src/` or card-logic changes — this is purely a packaging/CI fix. `npm run build` verified green.

## Delivery note

Merging this does **not** retroactively add assets to the already-published `4.2.0` release. After merge, push tag **`4.2.2`** on `master` to trigger the now-fixed workflow, which will publish a release **with** `tracking-number-card.js`, `.js.map`, and `.js.gz` assets. HACS users then get a valid card.

Fixes #27