### PR TITLE
docs: fill in Installation section (HACS + manual)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019-2026 Leonardo Merza
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,24 @@ A modern, customizable Home Assistant Lovelace card for displaying package track
 
 ## Installation
 
+This card requires the [tracking-numbers](https://github.com/ljmerza/tracking-numbers) custom integration to be installed and exposing a sensor with tracking data. HACS is the recommended way to install the card.
+
 ## Installation through [HACS](https://github.com/hacs/integration)
+
+1. Open **HACS** in Home Assistant.
+2. Go to **Frontend**, click **Explore & Download Repositories**, and search for **Tracking Number Card**.
+3. Select it, click **Download**, and choose the latest version.
+4. Hard-refresh your browser (Ctrl/Cmd + Shift + R) to clear the cached module.
+
+HACS automatically registers the Lovelace resource `/hacsfiles/tracking-number-card/tracking-number-card.js`. If your dashboard is in YAML mode, add it yourself under **Settings → Dashboards → Resources** as a **JavaScript Module**.
+
+## Manual installation
+
+1. Download `tracking-number-card.js` from the [latest release](https://github.com/ljmerza/tracking-number-card/releases/latest).
+2. Copy it to `config/www/tracking-number-card.js`.
+3. Go to **Settings → Dashboards → Resources → Add Resource**.
+4. Set the URL to `/local/tracking-number-card.js` and the type to **JavaScript Module**.
+5. Hard-refresh your browser.
 
 ### Configuration Options
 


### PR DESCRIPTION
The `## Installation` and `## Installation through HACS` headings in the README were empty (headers only). This fills them in:

- **Installation** — notes the `tracking-numbers` integration prerequisite and that HACS is recommended.
- **Installation through HACS** — numbered steps + a note that HACS auto-registers the `/hacsfiles/...` resource (and how to add it manually in YAML-mode dashboards).
- **Manual installation** — download the release asset, copy to `config/www/`, add the `/local/...` resource.

Docs-only; no code changes. Follows up on the packaging fix in #31 / #27.

Note (not changed here): `### Configuration Options` is a level-3 heading that would read better as a top-level `## Configuration` — left as-is to keep this PR minimal.