### PR TITLE
ci: move all actions off deprecated Node 20 runtimes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "lts/*"
           cache: "npm"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "lts/*"
           cache: "npm"
@@ -37,7 +37,7 @@ jobs:
           gzip -9 -k -c dist/tracking-number-card.js > release/tracking-number-card.js.gz
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: release/*
           generate_release_notes: true

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -10,7 +10,7 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v4"
       - name: HACS validation
         uses: "hacs/action@main"
         with:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -10,7 +10,7 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v5"
       - name: HACS validation
         uses: "hacs/action@main"
         with:


### PR DESCRIPTION
Every action pinned in this repo ran on **Node 20**, so each run emitted:

> ##[warning] Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: ...

Nothing fails today — GitHub shims node20 actions onto node24 — but the shim is temporary, and these break for real once it's removed.

### Changes

| Action | Before | After | Why |
|---|---|---|---|
| `actions/checkout` | `@v2` (validate), `@v4` (ci, release) | `@v5` | v4 is *also* node20; v5 is the first node24 release |
| `actions/setup-node` | `@v4` | `@v5` | v4 is node20; v5 is the first node24 release |
| `softprops/action-gh-release` | `@v2` | `@v3` | v2 is node20; v3.0.0 is a runtime-only move to node24 |

Each bump is to the **minimum** version on node24, so the runtime is the only thing that changes.

### Notes on the two breaking-change entries

- **setup-node v5** auto-enables package-manager caching when `package.json` has a `packageManager` field. This repo has no such field and both workflows already set `cache: "npm"` explicitly, so behavior is unchanged.
- **action-gh-release v3.0.0** is documented as purely moving the runtime Node 20 -> 24; `v2` stays pinned to the 2.x line for anyone needing node20.
- Both v5 lines require runner >= v2.327.1; GitHub-hosted runners satisfy this.

### Verification

`Validate` and `CI` runs on this branch: **zero** `Node.js 20 is deprecated` warnings (was 1 each), HACS still reports `All (8) checks passed`.

`release.yaml` only triggers on version tags, so its bumps are **not exercised by this PR** — they run on the next release tag.